### PR TITLE
give png format file to tesseract instead of tiff.

### DIFF
--- a/src/invoice2data/input/tesseract4.py
+++ b/src/invoice2data/input/tesseract4.py
@@ -54,7 +54,7 @@ def to_text(path, language='fra'):
             '0',
             '-sharpen',
             '0x1',
-            'tiff:-',
+            'png:-',
         ]
 
         p1 = subprocess.Popen(magick_cmd, stdout=subprocess.PIPE)


### PR DESCRIPTION
The tiff format preserves the text flow which causes tesseract to read the lines in the order in which they were written in the pdf instead of the way they appear on the pdf.